### PR TITLE
If creating a context and reusing it, the destruction of the reused conte

### DIFF
--- a/GLWallpaperService/src/net/rbgrn/android/glwallpaperservice/GLWallpaperService.java
+++ b/GLWallpaperService/src/net/rbgrn/android/glwallpaperservice/GLWallpaperService.java
@@ -316,6 +316,7 @@ class EglHelper {
 	private EGLDisplay mEglDisplay;
 	private EGLSurface mEglSurface;
 	private EGLContext mEglContext;
+	private int mEglContextCounter = 0;
 	EGLConfig mEglConfig;
 
 	private EGLConfigChooser mEGLConfigChooser;
@@ -379,7 +380,9 @@ class EglHelper {
 			if (mEglContext == null || mEglContext == EGL10.EGL_NO_CONTEXT) {
 				throw new RuntimeException("createContext failed");
 			}
+			++mEglContextCounter = 0;
 		} else {
+			++mEglContextCounter = 0;
 			// Log.d("EglHelper" + instanceId, "reusing context");
 		}
 
@@ -457,6 +460,7 @@ class EglHelper {
 	}
 
 	public void finish() {
+		if (--mEglContextCounter != 0) return;
 		if (mEglContext != null) {
 			mEGLContextFactory.destroyContext(mEgl, mEglDisplay, mEglContext);
 			mEglContext = null;


### PR DESCRIPTION
If creating a context and reusing it, the destruction of the reused context will destroy the original context. When previewing under certain conditions (using framebuffers, for some strange reason) this will crash the driver on the Samsung Galaxy S. Using a reuse counter fixes this problem.
