### PR TITLE
.classpath file removed from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ Thumbs.db
 .metadata
 .settings
 .project
-
+.classpath

--- a/GLWallpaperService/.classpath
+++ b/GLWallpaperService/.classpath
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="gen"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="output" path="bin/classes"/>
-</classpath>

--- a/GLWallpaperTest/.classpath
+++ b/GLWallpaperTest/.classpath
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="gen"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="src" path="GLWallpaperService_src"/>
-	<classpathentry kind="output" path="bin/classes"/>
-</classpath>


### PR DESCRIPTION
Since .classpath is created by eclipse, it's contents are dependent on the
users configuration, and has no use for users who have not set up this
project in eclipse it is being removed.

.classpath files are also now ignored via .gitignore

WARNING: This change will not be a problem moving forward but will likely break the project in Eclipse. This is because this is a file that eclipse uses to track project data. Any one who pulls this and has an eclipse project will need to either add the project again or fix their build settings for this project
