### PR TITLE
Deprecate redundant interfaces

### DIFF
--- a/GLWallpaperService/.classpath
+++ b/GLWallpaperService/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
+	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/GLWallpaperService/project.properties
+++ b/GLWallpaperService/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-7
+target=android-17
 android.library=true

--- a/GLWallpaperService/src/net/rbgrn/android/glwallpaperservice/GLWallpaperService.java
+++ b/GLWallpaperService/src/net/rbgrn/android/glwallpaperservice/GLWallpaperService.java
@@ -50,9 +50,9 @@ public class GLWallpaperService extends WallpaperService {
 		public final static int RENDERMODE_CONTINUOUSLY = 1;
 
 		private GLThread mGLThread;
-		private EGLConfigChooser mEGLConfigChooser;
-		private EGLContextFactory mEGLContextFactory;
-		private EGLWindowSurfaceFactory mEGLWindowSurfaceFactory;
+		private GLSurfaceView.EGLConfigChooser mEGLConfigChooser;
+		private GLSurfaceView.EGLContextFactory mEGLContextFactory;
+		private GLSurfaceView.EGLWindowSurfaceFactory mEGLWindowSurfaceFactory;
 		private GLWrapper mGLWrapper;
 		private int mDebugFlags;
 
@@ -119,7 +119,7 @@ public class GLWallpaperService extends WallpaperService {
 			return mDebugFlags;
 		}
 
-		public void setRenderer(Renderer renderer) {
+		public void setRenderer(GLSurfaceView.Renderer renderer) {
 			checkRenderThreadState();
 			if (mEGLConfigChooser == null) {
 				mEGLConfigChooser = new SimpleEGLConfigChooser(true);
@@ -134,17 +134,17 @@ public class GLWallpaperService extends WallpaperService {
 			mGLThread.start();
 		}
 
-		public void setEGLContextFactory(EGLContextFactory factory) {
+		public void setEGLContextFactory(GLSurfaceView.EGLContextFactory factory) {
 			checkRenderThreadState();
 			mEGLContextFactory = factory;
 		}
 
-		public void setEGLWindowSurfaceFactory(EGLWindowSurfaceFactory factory) {
+		public void setEGLWindowSurfaceFactory(GLSurfaceView.EGLWindowSurfaceFactory factory) {
 			checkRenderThreadState();
 			mEGLWindowSurfaceFactory = factory;
 		}
 
-		public void setEGLConfigChooser(EGLConfigChooser configChooser) {
+		public void setEGLConfigChooser(GLSurfaceView.EGLConfigChooser configChooser) {
 			checkRenderThreadState();
 			mEGLConfigChooser = configChooser;
 		}
@@ -190,8 +190,13 @@ public class GLWallpaperService extends WallpaperService {
 		}
 	}
 
+	/**
+	 * Empty wrapper for {@link GLSurfaceView.Renderer}.
+	 *
+	 * @deprecated Use {@link GLSurfaceView.Renderer} instead.
+	 */
+	@Deprecated
 	public interface Renderer extends GLSurfaceView.Renderer {
-
 	}
 }
 
@@ -231,19 +236,15 @@ class LogWriter extends Writer {
 // ----------------------------------------------------------------------
 
 /**
- * An interface for customizing the eglCreateContext and eglDestroyContext calls.
- *
-
- * This interface must be implemented by clients wishing to call
- * {@link GLWallpaperService#setEGLContextFactory(EGLContextFactory)}
+ * Empty wrapper for {@link GLSurfaceView.EGLContextFactory}.
+ * 
+ * @deprecated Use {@link GLSurfaceView.EGLContextFactory} instead.
  */
-interface EGLContextFactory {
-	EGLContext createContext(EGL10 egl, EGLDisplay display, EGLConfig eglConfig);
-
-	void destroyContext(EGL10 egl, EGLDisplay display, EGLContext context);
+@Deprecated
+interface EGLContextFactory extends GLSurfaceView.EGLContextFactory {
 }
 
-class DefaultContextFactory implements EGLContextFactory {
+class DefaultContextFactory implements GLSurfaceView.EGLContextFactory {
 
 	public EGLContext createContext(EGL10 egl, EGLDisplay display, EGLConfig config) {
 		return egl.eglCreateContext(display, config, EGL10.EGL_NO_CONTEXT, null);
@@ -255,19 +256,15 @@ class DefaultContextFactory implements EGLContextFactory {
 }
 
 /**
- * An interface for customizing the eglCreateWindowSurface and eglDestroySurface calls.
- *
-
- * This interface must be implemented by clients wishing to call
- * {@link GLWallpaperService#setEGLWindowSurfaceFactory(EGLWindowSurfaceFactory)}
+ * Empty wrapper for {@link GLSurfaceView.EGLWindowSurfaceFactory}.
+ * 
+ * @deprecated Use {@link GLSurfaceView.EGLWindowSurfaceFactory} instead.
  */
-interface EGLWindowSurfaceFactory {
-	EGLSurface createWindowSurface(EGL10 egl, EGLDisplay display, EGLConfig config, Object nativeWindow);
-
-	void destroySurface(EGL10 egl, EGLDisplay display, EGLSurface surface);
+@Deprecated
+interface EGLWindowSurfaceFactory extends GLSurfaceView.EGLWindowSurfaceFactory {
 }
 
-class DefaultWindowSurfaceFactory implements EGLWindowSurfaceFactory {
+class DefaultWindowSurfaceFactory implements GLSurfaceView.EGLWindowSurfaceFactory {
 
 	public EGLSurface createWindowSurface(EGL10 egl, EGLDisplay
 			display, EGLConfig config, Object nativeWindow) {
@@ -314,13 +311,13 @@ class EglHelper {
 	private EGLContext mEglContext;
 	EGLConfig mEglConfig;
 
-	private EGLConfigChooser mEGLConfigChooser;
-	private EGLContextFactory mEGLContextFactory;
-	private EGLWindowSurfaceFactory mEGLWindowSurfaceFactory;
+	private GLSurfaceView.EGLConfigChooser mEGLConfigChooser;
+	private GLSurfaceView.EGLContextFactory mEGLContextFactory;
+	private GLSurfaceView.EGLWindowSurfaceFactory mEGLWindowSurfaceFactory;
 	private GLWrapper mGLWrapper;
 
-	public EglHelper(EGLConfigChooser chooser, EGLContextFactory contextFactory,
-			EGLWindowSurfaceFactory surfaceFactory, GLWrapper wrapper) {
+	public EglHelper(GLSurfaceView.EGLConfigChooser chooser, GLSurfaceView.EGLContextFactory contextFactory,
+			GLSurfaceView.EGLWindowSurfaceFactory surfaceFactory, GLWrapper wrapper) {
 		this.mEGLConfigChooser = chooser;
 		this.mEGLContextFactory = contextFactory;
 		this.mEGLWindowSurfaceFactory = surfaceFactory;
@@ -472,9 +469,9 @@ class GLThread extends Thread {
 	private final GLThreadManager sGLThreadManager = new GLThreadManager();
 	private GLThread mEglOwner;
 
-	private EGLConfigChooser mEGLConfigChooser;
-	private EGLContextFactory mEGLContextFactory;
-	private EGLWindowSurfaceFactory mEGLWindowSurfaceFactory;
+	private GLSurfaceView.EGLConfigChooser mEGLConfigChooser;
+	private GLSurfaceView.EGLContextFactory mEGLContextFactory;
+	private GLSurfaceView.EGLWindowSurfaceFactory mEGLWindowSurfaceFactory;
 	private GLWrapper mGLWrapper;
 
 	public SurfaceHolder mHolder;
@@ -494,12 +491,12 @@ class GLThread extends Thread {
 	private boolean mEventsWaiting;
 	// End of member variables protected by the sGLThreadManager monitor.
 
-	private GLWallpaperService.Renderer mRenderer;
+	private GLSurfaceView.Renderer mRenderer;
 	private ArrayList<Runnable> mEventQueue = new ArrayList<Runnable>();
 	private EglHelper mEglHelper;
 
-	GLThread(GLWallpaperService.Renderer renderer, EGLConfigChooser chooser, EGLContextFactory contextFactory,
-			EGLWindowSurfaceFactory surfaceFactory, GLWrapper wrapper) {
+	GLThread(GLSurfaceView.Renderer renderer, GLSurfaceView.EGLConfigChooser chooser, GLSurfaceView.EGLContextFactory contextFactory,
+			GLSurfaceView.EGLWindowSurfaceFactory surfaceFactory, GLWrapper wrapper) {
 		super();
 		mDone = false;
 		mWidth = 0;
@@ -836,11 +833,16 @@ class GLThread extends Thread {
 	}
 }
 
-interface EGLConfigChooser {
-	EGLConfig chooseConfig(EGL10 egl, EGLDisplay display);
+/**
+ * Empty wrapper for {@link GLSurfaceView.EGLConfigChooser}.
+ *
+ * @deprecated Use {@link GLSurfaceView.EGLConfigChooser} instead.
+ */
+@Deprecated
+interface EGLConfigChooser extends GLSurfaceView.EGLConfigChooser {
 }
 
-abstract class BaseConfigChooser implements EGLConfigChooser {
+abstract class BaseConfigChooser implements GLSurfaceView.EGLConfigChooser {
 	public BaseConfigChooser(int[] configSpec) {
 		mConfigSpec = configSpec;
 	}

--- a/GLWallpaperService/src/net/rbgrn/android/glwallpaperservice/GLWallpaperService.java
+++ b/GLWallpaperService/src/net/rbgrn/android/glwallpaperservice/GLWallpaperService.java
@@ -53,7 +53,7 @@ public class GLWallpaperService extends WallpaperService {
 		private GLSurfaceView.EGLConfigChooser mEGLConfigChooser;
 		private GLSurfaceView.EGLContextFactory mEGLContextFactory;
 		private GLSurfaceView.EGLWindowSurfaceFactory mEGLWindowSurfaceFactory;
-		private GLWrapper mGLWrapper;
+		private GLSurfaceView.GLWrapper mGLWrapper;
 		private int mDebugFlags;
 
 		public GLEngine() {
@@ -107,7 +107,7 @@ public class GLWallpaperService extends WallpaperService {
 		/**
 		 * An EGL helper class.
 		 */
-		public void setGLWrapper(GLWrapper glWrapper) {
+		public void setGLWrapper(GLSurfaceView.GLWrapper glWrapper) {
 			mGLWrapper = glWrapper;
 		}
 
@@ -237,7 +237,7 @@ class LogWriter extends Writer {
 
 /**
  * Empty wrapper for {@link GLSurfaceView.EGLContextFactory}.
- * 
+ *
  * @deprecated Use {@link GLSurfaceView.EGLContextFactory} instead.
  */
 @Deprecated
@@ -257,7 +257,7 @@ class DefaultContextFactory implements GLSurfaceView.EGLContextFactory {
 
 /**
  * Empty wrapper for {@link GLSurfaceView.EGLWindowSurfaceFactory}.
- * 
+ *
  * @deprecated Use {@link GLSurfaceView.EGLWindowSurfaceFactory} instead.
  */
 @Deprecated
@@ -292,15 +292,13 @@ class DefaultWindowSurfaceFactory implements GLSurfaceView.EGLWindowSurfaceFacto
 	}
 }
 
-interface GLWrapper {
-	/**
-	 * Wraps a gl interface in another gl interface.
-	 *
-	 * @param gl
-	 * a GL interface that is to be wrapped.
-	 * @return either the input argument or another GL object that wraps the input argument.
-	 */
-	GL wrap(GL gl);
+/**
+ * Empty wrapper for {@link GLSurfaceView.GLWrapper}.
+ *
+ * @deprecated Use {@link GLSurfaceView.GLWrapper} instead.
+ */
+@Deprecated
+interface GLWrapper extends GLSurfaceView.GLWrapper {
 }
 
 class EglHelper {
@@ -314,10 +312,10 @@ class EglHelper {
 	private GLSurfaceView.EGLConfigChooser mEGLConfigChooser;
 	private GLSurfaceView.EGLContextFactory mEGLContextFactory;
 	private GLSurfaceView.EGLWindowSurfaceFactory mEGLWindowSurfaceFactory;
-	private GLWrapper mGLWrapper;
+	private GLSurfaceView.GLWrapper mGLWrapper;
 
 	public EglHelper(GLSurfaceView.EGLConfigChooser chooser, GLSurfaceView.EGLContextFactory contextFactory,
-			GLSurfaceView.EGLWindowSurfaceFactory surfaceFactory, GLWrapper wrapper) {
+			GLSurfaceView.EGLWindowSurfaceFactory surfaceFactory, GLSurfaceView.GLWrapper wrapper) {
 		this.mEGLConfigChooser = chooser;
 		this.mEGLContextFactory = contextFactory;
 		this.mEGLWindowSurfaceFactory = surfaceFactory;
@@ -472,7 +470,7 @@ class GLThread extends Thread {
 	private GLSurfaceView.EGLConfigChooser mEGLConfigChooser;
 	private GLSurfaceView.EGLContextFactory mEGLContextFactory;
 	private GLSurfaceView.EGLWindowSurfaceFactory mEGLWindowSurfaceFactory;
-	private GLWrapper mGLWrapper;
+	private GLSurfaceView.GLWrapper mGLWrapper;
 
 	public SurfaceHolder mHolder;
 	private boolean mSizeChanged = true;
@@ -496,7 +494,7 @@ class GLThread extends Thread {
 	private EglHelper mEglHelper;
 
 	GLThread(GLSurfaceView.Renderer renderer, GLSurfaceView.EGLConfigChooser chooser, GLSurfaceView.EGLContextFactory contextFactory,
-			GLSurfaceView.EGLWindowSurfaceFactory surfaceFactory, GLWrapper wrapper) {
+			GLSurfaceView.EGLWindowSurfaceFactory surfaceFactory, GLSurfaceView.GLWrapper wrapper) {
 		super();
 		mDone = false;
 		mWidth = 0;

--- a/GLWallpaperTest/project.properties
+++ b/GLWallpaperTest/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-7
+target=android-17
 android.library.reference.1=../GLWallpaperService

--- a/GLWallpaperTest/src/net/markguerra/android/glwallpapertest/MyRenderer.java
+++ b/GLWallpaperTest/src/net/markguerra/android/glwallpapertest/MyRenderer.java
@@ -3,12 +3,12 @@ package net.markguerra.android.glwallpapertest;
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
 
-import net.rbgrn.android.glwallpaperservice.*;
+import android.opengl.GLSurfaceView;
 import android.opengl.GLU;
 
 // Original code provided by Robert Green
 // http://www.rbgrn.net/content/354-glsurfaceview-adapted-3d-live-wallpapers
-public class MyRenderer implements GLWallpaperService.Renderer {
+public class MyRenderer implements GLSurfaceView.Renderer {
 	private GLCube mCube;
 
 	// Used for Lighting


### PR DESCRIPTION
Many of the interfaces are exact duplicates of ones from `GLSurfaceView`
and, as far as I can tell, add no value. While integrating the latest
code into the downstream [Rajawali](https://github.com/MasDennis/Rajawali) framework, I found these interfaces to
be a nuisance. Our classes, which already implement the `GLSurfaceView`
interfaces, were not considered valid to the `GLWallpaperService`.

`GLWallpaperService` has been modified to accept the `GLSurfaceView`
interfaces. To maintain backwards compatibility, the redundant
`GLWallpaperService` interfaces have been changed to empty extensions of
their `GLSurfaceView` counterparts, but marked as deprecated. The downside
of keeping the interfaces for backwards compatibility is that
"`GLSurfaceView.`" had to be prefixed onto many declarations.
## Alternate Implementation
#26 is a cleaner, less verbose variation of this pull request. However, it breaks backwards compatibility. Only one or the other should be merged.
