### PR TITLE
Remove and replace redundant interfaces

### DIFF
--- a/GLWallpaperService/.classpath
+++ b/GLWallpaperService/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
+	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/GLWallpaperService/project.properties
+++ b/GLWallpaperService/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-7
+target=android-17
 android.library=true

--- a/GLWallpaperTest/project.properties
+++ b/GLWallpaperTest/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-7
+target=android-17
 android.library.reference.1=../GLWallpaperService

--- a/GLWallpaperTest/src/net/markguerra/android/glwallpapertest/MyRenderer.java
+++ b/GLWallpaperTest/src/net/markguerra/android/glwallpapertest/MyRenderer.java
@@ -3,12 +3,12 @@ package net.markguerra.android.glwallpapertest;
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
 
-import net.rbgrn.android.glwallpaperservice.*;
+import android.opengl.GLSurfaceView;
 import android.opengl.GLU;
 
 // Original code provided by Robert Green
 // http://www.rbgrn.net/content/354-glsurfaceview-adapted-3d-live-wallpapers
-public class MyRenderer implements GLWallpaperService.Renderer {
+public class MyRenderer implements GLSurfaceView.Renderer {
 	private GLCube mCube;
 
 	// Used for Lighting


### PR DESCRIPTION
Many of the interfaces are exact duplicates of ones from `GLSurfaceView`
and, as far as I can tell, add no value. While integrating the latest
code into the downstream [Rajawali](https://github.com/MasDennis/Rajawali) framework, I found these interfaces to
be a nuisance. Our classes, which already implement the `GLSurfaceView`
interfaces, were not considered valid to the `GLWallpaperService`.

`GLWallpaperService` has been modified to accept the `GLSurfaceView`
interfaces. The local duplicates have been removed. This will break
backward compatibility for projects that use the local variant, but the
fix is easy: replace the "`GLWallpaperService.`" prefix with a
"`GLSurfaceView.`" prefix or tweak the import statements.
## Alternate Implementation
#25 is a variation of this pull request that maintains backward compatibility and merely deprecates the duplicate interfaces. However, it is more verbose and "ugly". Only one or the other should be merged.
